### PR TITLE
Support to filter classes based on modifiers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
     <maven.site.deploy.skip>true</maven.site.deploy.skip>
     <maven.tools-version>3.2.5</maven.tools-version>
     <mavenPluginToolsVersion>3.5</mavenPluginToolsVersion>
+    <mockitoVersion>1.10.19</mockitoVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <sourceReleaseAssemblyDescriptor>source-release-tar</sourceReleaseAssemblyDescriptor>
@@ -113,6 +114,11 @@
         <artifactId>maven-plugin-annotations</artifactId>
         <version>${mavenPluginToolsVersion}</version>
       </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-all</artifactId>
+        <version>${mockitoVersion}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -138,6 +144,11 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/net/revelc/code/warbucks/maven/plugin/Rule.java
+++ b/src/main/java/net/revelc/code/warbucks/maven/plugin/Rule.java
@@ -20,7 +20,10 @@ public class Rule {
   private String classPattern;
   private boolean includeMainClasses = true;
   private boolean includeTestClasses = false;
-
+  private boolean includePublicClasses = true;
+  private boolean includePackagePrivateClasses = true;
+  private boolean includeProtectedClasses = true;
+  private boolean includePrivateClasses = true;
   public String getClassAnnotationPattern() {
     return classAnnotationPattern;
   }
@@ -37,4 +40,16 @@ public class Rule {
     return includeTestClasses;
   }
 
+  public boolean getIncludePublicClasses() {
+    return includePublicClasses;
+  }
+  public boolean getIncludePackagePrivateClasses() {
+    return includePackagePrivateClasses;
+  }
+  public boolean getIncludeProtectedClasses() {
+    return includeProtectedClasses;
+  }
+  public boolean getIncludePrivateClasses() {
+    return includePrivateClasses;
+  }
 }

--- a/src/main/java/net/revelc/code/warbucks/maven/plugin/RuleProcessor.java
+++ b/src/main/java/net/revelc/code/warbucks/maven/plugin/RuleProcessor.java
@@ -14,6 +14,7 @@
 
 package net.revelc.code.warbucks.maven.plugin;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
@@ -101,18 +102,24 @@ class RuleProcessor {
   }
 
   private Predicate<ClassInfo> isValidModifier() {
-    return clz -> {
-      int mod = clz.load().getModifiers();
-      if (Modifier.isPublic(mod)) {
-        return rule.getIncludePublicClasses();
-      } else if (Modifier.isProtected(mod)) {
-        return rule.getIncludeProtectedClasses();
-      } else if (Modifier.isPrivate(mod)) {
-        return rule.getIncludePrivateClasses();
-      } else {
-        return rule.getIncludePackagePrivateClasses();
-      }
-     };
+    return classInfo ->
+      rule.getIncludePublicClasses() && rule.getIncludeProtectedClasses() &&
+        rule.getIncludePackagePrivateClasses() && rule.getIncludePrivateClasses() ? true
+        : isValidModifier(classInfo.load(), rule);
+  }
+
+  @VisibleForTesting
+  static boolean isValidModifier(Class clz, Rule rule) {
+    int mod = clz.getModifiers();
+    if (Modifier.isPublic(mod)) {
+      return rule.getIncludePublicClasses();
+    } else if (Modifier.isProtected(mod)) {
+      return rule.getIncludeProtectedClasses();
+    } else if (Modifier.isPrivate(mod)) {
+      return rule.getIncludePrivateClasses();
+    } else {
+      return rule.getIncludePackagePrivateClasses();
+    }
   }
 
   // only check classes which match the specified pattern

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -43,10 +43,18 @@ Getting Started
         <version>${project.version}</version>
         <configuration>
           <rules>
-            <!-- Example rule to ensure integration tests have a JUnit Category -->
+            <!-- Example rule to ensure Public integration tests have a JUnit Category -->
             <rule>
               <!-- a pattern of classes for which to check annotations -->
               <classPattern>.*IT</classPattern>
+              <!-- include the classes which have Public modifier -->
+              <includePublicClasses>true</includePublicClasses>
+              <!-- exclude the classes which have Package-private modifier -->
+              <includePackagePrivateClasses>false</includePackagePrivateClasses>
+              <!-- exclude the classes which have Protected modifier -->
+              <includeProtectedClasses>false</includeProtectedClasses>
+              <!-- exclude the classes which have Private modifier -->
+              <includePrivateClasses>false</includePrivateClasses>
               <!-- a pattern of annotations which are required for the specified classes -->
               <classAnnotationPattern>org[.]junit[.]experimental[.]categories[.]Category</classAnnotationPattern>
             </rule>

--- a/src/test/java/net/revelc/code/warbucks/maven/plugin/TestRuleProcessor.java
+++ b/src/test/java/net/revelc/code/warbucks/maven/plugin/TestRuleProcessor.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.revelc.code.warbucks.maven.plugin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class TestRuleProcessor {
+
+  @Test
+  public void testValidModifier() {
+    List<Class> allClasses = Arrays.asList(
+      PublicClass.class,
+      PackagePrivateClass.class,
+      ProtectedClass.class,
+      PrivateClass.class
+    );
+    int testCount = 0;
+    for (EnumSet<Modifier> modifiers : combineModifiers()) {
+      assertFalse(modifiers.isEmpty());
+      ++testCount;
+      Rule rule = createRule(modifiers);
+      List<Class> valid = allClasses.stream()
+        .filter(clz -> RuleProcessor.isValidModifier(clz, rule))
+        .collect(Collectors.toList());
+      assertEquals(rule.getIncludePublicClasses(), valid.contains(PublicClass.class));
+      assertEquals(rule.getIncludePackagePrivateClasses(), valid.contains(PackagePrivateClass.class));
+      assertEquals(rule.getIncludeProtectedClasses(), valid.contains(ProtectedClass.class));
+      assertEquals(rule.getIncludePrivateClasses(), valid.contains(PrivateClass.class));
+    }
+    assertTrue(testCount != 0);
+  }
+
+  private static List<EnumSet<Modifier>> combineModifiers() {
+    List<EnumSet<Modifier>> single = Arrays.asList(
+      EnumSet.of(Modifier.PUBLIC),
+      EnumSet.of(Modifier.PACKAGE_PRIVATE),
+      EnumSet.of(Modifier.PROTECTED),
+      EnumSet.of(Modifier.PRIVATE)
+    );
+    List<EnumSet<Modifier>> all = new ArrayList<>(single);
+    List<EnumSet<Modifier>> last = single;
+    for (int i = 1; i < Modifier.values().length; ++i) {
+      last = merge(single, last, i + 1);
+      all.addAll(last);
+    }
+    return all;
+  }
+
+  private static List<EnumSet<Modifier>> merge(List<EnumSet<Modifier>> lhs,
+    List<EnumSet<Modifier>> rhs, int expectedSize) {
+    List<EnumSet<Modifier>> merged = new ArrayList<>();
+    for (EnumSet<Modifier> s0 : lhs) {
+      for (EnumSet<Modifier> s1 : rhs) {
+        if (s0.equals(s1)) {
+          continue;
+        }
+        EnumSet<Modifier> merge = EnumSet.copyOf(s0);
+        merge.addAll(s1);
+        if (merge.size() == expectedSize
+          && !merged.contains(merge)) {
+          merged.add(merge);
+        }
+      }
+    }
+    return merged;
+  }
+
+  /**
+   * @return a mock Rule having passed modifiers
+   */
+  private static Rule createRule(EnumSet<Modifier> modifiers) {
+    Rule rule = Mockito.mock(Rule.class);
+    for (Modifier mod : Modifier.values()) {
+      boolean value = modifiers.contains(mod);
+      switch (mod) {
+        case PUBLIC:
+          Mockito.when(rule.getIncludePublicClasses()).thenReturn(value);
+          break;
+        case PACKAGE_PRIVATE:
+          Mockito.when(rule.getIncludePackagePrivateClasses()).thenReturn(value);
+          break;
+        case PROTECTED:
+          Mockito.when(rule.getIncludeProtectedClasses()).thenReturn(value);
+          break;
+        case PRIVATE:
+          Mockito.when(rule.getIncludePrivateClasses()).thenReturn(value);
+          break;
+        default:
+          throw new RuntimeException("Unsupported modififer:" + mod);
+      }
+    }
+    return rule;
+  }
+
+  enum Modifier {
+    PUBLIC, PACKAGE_PRIVATE, PROTECTED, PRIVATE
+  }
+
+  public static class PublicClass {}
+  static class PackagePrivateClass {}
+  protected static class ProtectedClass {}
+  private static class PrivateClass {}
+}


### PR DESCRIPTION
hi warbucks-maven-plugin
HBase plans to use this nice plugin to find out the classes having no specified annotations. However, the classes HBase cares are only the Public classes. This PR enable this plugin to filter classes based on the specified modifiers.

Related issue:
https://issues.apache.org/jira/browse/HBASE-19713

Best Regards
Ping